### PR TITLE
Passo a passo de instalação do Visual Studio Code no macOS

### DIFF
--- a/tutoriais/vscode/macOS/macOS.md
+++ b/tutoriais/vscode/macOS/macOS.md
@@ -4,7 +4,7 @@ Neste texto você instalará o **VS Code** no **macOS**.
 
 Obs.: Para instalar em outros sistemas operacionais, visite [este link](https://github.com/guiemi/como-instalar-xyz#editores-de-texto-ides-e-etc).
 
-O **Visual Studio Code**, popularmente conhecido como **VS Code**, é um editor de texto open-source construído pela Microsoft. Ele vem ganhando popularidade graças à sua fluidez e à sua facilidade de uso. Com ferramentas nativas interessantes e uma notável quantidade de plugins disponíveis para download, o **VS Code** é certamente um dos melhores editores de código disponíveis atualmente.
+O **Visual Studio Code**, popularmente conhecido como **VS Code**, é um editor de texto open-source feito pela Microsoft. Ele vem ganhando popularidade graças à sua fluidez e à sua facilidade de uso. Com ferramentas nativas interessantes e uma notável quantidade de plugins disponíveis para download, o **VS Code** é certamente um dos melhores editores de código disponíveis atualmente.
 
 ### Requisitos:
 
@@ -14,11 +14,19 @@ O **Visual Studio Code**, popularmente conhecido como **VS Code**, é um editor 
 
 Visite a página de download através do link: https://code.visualstudio.com/download. Uma página de download do software para todas as plataformas disponíveis se abrirá. 
 
-1. Clique no botão correspondente ao macOS para iniciar o download do arquivo `.zip`. Seu navegador será redirecionado para a documentação do editor e então o download será iniciado. 
-2. Após o término do download, utilize o **Finder** para localizar o arquivo `VSCode-darwin-stable.zip`. Ele provavelmente está na sua pasta `Downloads.` 
-   * Se não estiver, utilize `option + command + L` no Chrome ou `command + Y` no Safari para que o navegador mostre seus últimos downloads.
-3. Encontrado o arquivo, você precisa extraí-lo: dê um clique duplo nele, passe o mouse sobre "*Open with*" e selecione o **Archive Utility** para que a extração seja iniciada.
-4. O próximo passo é manualmente arrastar o arquivo extraído para a sua pasta Applications:
-   * Abra uma nova janela do **Finder** através do atalho `option + command + N`
-   * Na sidebar, clique em **Applications** para abrir a pasta
-5. Pronto!, o **VS Code** já está instalado no seu Macintosh e disponível para ser iniciado a partir do **Launchpad**.
+* Clique no botão correspondente ao macOS para iniciar o download do arquivo `.zip`. Seu navegador será redirecionado para a documentação do editor e então o download será iniciado. 
+
+* Após o término do download, utilize o **Finder** para localizar o arquivo `VSCode-darwin-stable.zip`. Ele provavelmente está na sua pasta `Downloads.` 
+  * Se não estiver, utilize `option + command + L` no Chrome ou `command + Y` no Safari para que o navegador mostre seus últimos downloads.
+
+## Extraindo o arquivo baixado
+
+* Encontrado o arquivo, você precisa extraí-lo: dê um clique duplo nele, passe o mouse sobre "*Open with*" e selecione o **Archive Utility** para que a extração seja iniciada.
+
+## Instalando
+
+* O próximo passo é manualmente arrastar o arquivo extraído para a sua pasta Applications:
+  * Abra uma nova janela do **Finder** através do atalho `option + command + N`
+  * Na sidebar, clique em **Applications** para abrir a pasta
+
+* Pronto!, o **VS Code** já está instalado no seu Macintosh e disponível para ser iniciado a partir do **Launchpad**.

--- a/tutoriais/vscode/macOS/macOS.md
+++ b/tutoriais/vscode/macOS/macOS.md
@@ -17,7 +17,7 @@ Visite a página de download através do link: https://code.visualstudio.com/dow
 * Clique no botão correspondente ao macOS para iniciar o download do arquivo `.zip`. Seu navegador será redirecionado para a documentação do editor e então o download será iniciado. 
 
 * Após o término do download, utilize o **Finder** para localizar o arquivo `VSCode-darwin-stable.zip`. Ele provavelmente está na sua pasta `Downloads.` 
-  * Se não estiver, utilize   ⎇ ⌘ L no Chrome ou `⌘ Y` no Safari para que o navegador mostre seus últimos downloads.
+  * Se não estiver, utilize `option command L  ` (⌥ ⌘ L) no Chrome ou `command Y`   (⌘ Y) no Safari para que o navegador mostre seus últimos downloads.
 
 ## Extraindo o arquivo baixado
 
@@ -26,7 +26,7 @@ Visite a página de download através do link: https://code.visualstudio.com/dow
 ## Instalando
 
 * O próximo passo é manualmente arrastar o arquivo extraído para a sua pasta Applications:
-  * Abra uma nova janela do **Finder** através do atalho `⌥ ⌘ N`
+  * Abra uma nova janela do **Finder** através do atalho `option command N`  (⌥ ⌘ N)
   * Na sidebar, clique em **Applications** para abrir a pasta
 
 * Pronto!, o **VS Code** já está instalado no seu Macintosh e disponível para ser iniciado a partir do **Launchpad**.

--- a/tutoriais/vscode/macOS/macOS.md
+++ b/tutoriais/vscode/macOS/macOS.md
@@ -1,0 +1,24 @@
+# Como instalar o VSCode no macOS
+
+Neste texto você aprenderá a instalar o VSCode no macOS. Para instalar em outros sistemas operacionais, visite [este link](https://github.com/guiemi/como-instalar-xyz#editores-de-texto-ides-e-etc).
+
+O Visual Studio Code, popularmente conhecido como VSCode, é um editor de texto open-source construído pela Microsoft. Ele vem ganhando popularidade graças à sua fluidez e à sua facilidade de uso. Com ferramentas nativas interessantes e uma notável quantidade de plugins disponíveis para download, o VSCode é certamente um dos melhores editores de código disponíveis atualmente.
+
+### Requisitos:
+
+* macOS 10.9+
+
+## Baixando o Visual Studio Code
+
+Visite a página de download através do link: https://code.visualstudio.com/download. Uma página de download do software para todas as plataformas disponíveis se abrirá. 
+
+* Clique no botão correspondente ao macOS para iniciar o download do arquivo .zip. Seu navegador será redirecionado para a documentação do editor e então o download será iniciado. 
+
+* Após o término do download, utilize o Finder   para localizar o arquivo **VSCode-darwin-stable.zip**. Ele provavelmente está na sua pasta *Downloads.* 
+  * Se não estiver, utilize "*option + command + L*" no Chrome ou "*command + Y*" no Safari para que o navegador mostre seus últimos downloads.
+
+* Encontrado o arquivo, você precisa extraí-lo: dê um clique duplo nele, passe o mouse sobre "Open with" e selecione o Archive Utility para que a extração seja iniciada.
+* O próximo passo é manualmente arrastar o arquivo extraído para a sua pasta Applications:
+  * Abra uma nova janela do Finder através do atalho "option + command + N"
+  * Na sidebar, clique em *Applications* para abrir a pasta
+* Pronto!, o VSCode já está instalado no seu Mac!

--- a/tutoriais/vscode/macOS/macOS.md
+++ b/tutoriais/vscode/macOS/macOS.md
@@ -1,24 +1,24 @@
-# Como instalar o VSCode no macOS
+# Instalando o Visual Studio Code no macOS
 
-Neste texto você aprenderá a instalar o VSCode no macOS. Para instalar em outros sistemas operacionais, visite [este link](https://github.com/guiemi/como-instalar-xyz#editores-de-texto-ides-e-etc).
+Neste texto você instalará o **VS Code** no **macOS**. 
 
-O Visual Studio Code, popularmente conhecido como VSCode, é um editor de texto open-source construído pela Microsoft. Ele vem ganhando popularidade graças à sua fluidez e à sua facilidade de uso. Com ferramentas nativas interessantes e uma notável quantidade de plugins disponíveis para download, o VSCode é certamente um dos melhores editores de código disponíveis atualmente.
+Obs.: Para instalar em outros sistemas operacionais, visite [este link](https://github.com/guiemi/como-instalar-xyz#editores-de-texto-ides-e-etc).
+
+O **Visual Studio Code**, popularmente conhecido como **VS Code**, é um editor de texto open-source construído pela Microsoft. Ele vem ganhando popularidade graças à sua fluidez e à sua facilidade de uso. Com ferramentas nativas interessantes e uma notável quantidade de plugins disponíveis para download, o **VS Code** é certamente um dos melhores editores de código disponíveis atualmente.
 
 ### Requisitos:
 
-* macOS 10.9+
+* `macOS 10.9+`
 
 ## Baixando o Visual Studio Code
 
 Visite a página de download através do link: https://code.visualstudio.com/download. Uma página de download do software para todas as plataformas disponíveis se abrirá. 
 
-* Clique no botão correspondente ao macOS para iniciar o download do arquivo .zip. Seu navegador será redirecionado para a documentação do editor e então o download será iniciado. 
-
-* Após o término do download, utilize o Finder   para localizar o arquivo **VSCode-darwin-stable.zip**. Ele provavelmente está na sua pasta *Downloads.* 
-  * Se não estiver, utilize "*option + command + L*" no Chrome ou "*command + Y*" no Safari para que o navegador mostre seus últimos downloads.
-
-* Encontrado o arquivo, você precisa extraí-lo: dê um clique duplo nele, passe o mouse sobre "Open with" e selecione o Archive Utility para que a extração seja iniciada.
-* O próximo passo é manualmente arrastar o arquivo extraído para a sua pasta Applications:
-  * Abra uma nova janela do Finder através do atalho "option + command + N"
-  * Na sidebar, clique em *Applications* para abrir a pasta
-* Pronto!, o VSCode já está instalado no seu Mac!
+1. Clique no botão correspondente ao macOS para iniciar o download do arquivo `.zip`. Seu navegador será redirecionado para a documentação do editor e então o download será iniciado. 
+2. Após o término do download, utilize o **Finder** para localizar o arquivo `VSCode-darwin-stable.zip`. Ele provavelmente está na sua pasta `Downloads.` 
+   * Se não estiver, utilize `option + command + L` no Chrome ou `command + Y` no Safari para que o navegador mostre seus últimos downloads.
+3. Encontrado o arquivo, você precisa extraí-lo: dê um clique duplo nele, passe o mouse sobre "*Open with*" e selecione o **Archive Utility** para que a extração seja iniciada.
+4. O próximo passo é manualmente arrastar o arquivo extraído para a sua pasta Applications:
+   * Abra uma nova janela do **Finder** através do atalho `option + command + N`
+   * Na sidebar, clique em **Applications** para abrir a pasta
+5. Pronto!, o **VS Code** já está instalado no seu Macintosh e disponível para ser iniciado a partir do **Launchpad**.

--- a/tutoriais/vscode/macOS/macOS.md
+++ b/tutoriais/vscode/macOS/macOS.md
@@ -17,7 +17,7 @@ Visite a página de download através do link: https://code.visualstudio.com/dow
 * Clique no botão correspondente ao macOS para iniciar o download do arquivo `.zip`. Seu navegador será redirecionado para a documentação do editor e então o download será iniciado. 
 
 * Após o término do download, utilize o **Finder** para localizar o arquivo `VSCode-darwin-stable.zip`. Ele provavelmente está na sua pasta `Downloads.` 
-  * Se não estiver, utilize `option + command + L` no Chrome ou `command + Y` no Safari para que o navegador mostre seus últimos downloads.
+  * Se não estiver, utilize   `⌥ ⌘ L` no Chrome ou `⌘ Y` no Safari para que o navegador mostre seus últimos downloads.
 
 ## Extraindo o arquivo baixado
 
@@ -26,7 +26,7 @@ Visite a página de download através do link: https://code.visualstudio.com/dow
 ## Instalando
 
 * O próximo passo é manualmente arrastar o arquivo extraído para a sua pasta Applications:
-  * Abra uma nova janela do **Finder** através do atalho `option + command + N`
+  * Abra uma nova janela do **Finder** através do atalho `⌥ ⌘ N`
   * Na sidebar, clique em **Applications** para abrir a pasta
 
 * Pronto!, o **VS Code** já está instalado no seu Macintosh e disponível para ser iniciado a partir do **Launchpad**.

--- a/tutoriais/vscode/macOS/macOS.md
+++ b/tutoriais/vscode/macOS/macOS.md
@@ -17,7 +17,7 @@ Visite a página de download através do link: https://code.visualstudio.com/dow
 * Clique no botão correspondente ao macOS para iniciar o download do arquivo `.zip`. Seu navegador será redirecionado para a documentação do editor e então o download será iniciado. 
 
 * Após o término do download, utilize o **Finder** para localizar o arquivo `VSCode-darwin-stable.zip`. Ele provavelmente está na sua pasta `Downloads.` 
-  * Se não estiver, utilize   `⌥ ⌘ L` no Chrome ou `⌘ Y` no Safari para que o navegador mostre seus últimos downloads.
+  * Se não estiver, utilize  ` ⎇ ⌘ L` no Chrome ou `⌘ Y` no Safari para que o navegador mostre seus últimos downloads.
 
 ## Extraindo o arquivo baixado
 

--- a/tutoriais/vscode/macOS/macOS.md
+++ b/tutoriais/vscode/macOS/macOS.md
@@ -17,7 +17,7 @@ Visite a página de download através do link: https://code.visualstudio.com/dow
 * Clique no botão correspondente ao macOS para iniciar o download do arquivo `.zip`. Seu navegador será redirecionado para a documentação do editor e então o download será iniciado. 
 
 * Após o término do download, utilize o **Finder** para localizar o arquivo `VSCode-darwin-stable.zip`. Ele provavelmente está na sua pasta `Downloads.` 
-  * Se não estiver, utilize  ` ⎇ ⌘ L` no Chrome ou `⌘ Y` no Safari para que o navegador mostre seus últimos downloads.
+  * Se não estiver, utilize   ⎇ ⌘ L no Chrome ou `⌘ Y` no Safari para que o navegador mostre seus últimos downloads.
 
 ## Extraindo o arquivo baixado
 


### PR DESCRIPTION
Este PR visa adicionar um texto em markdown com um tutorial de instalação do VS Code em máquinas rodando o macOS.

Como sugestão de próximas alterações no texto, deixo como sugestão:

- Inserir screenshots