### PR TITLE
Redução de linhas

### DIFF
--- a/tutoriais/git/linux/ubuntu.md
+++ b/tutoriais/git/linux/ubuntu.md
@@ -1,16 +1,6 @@
 # Git
 
-Uma maneira prática de realizar a instalação do gerenciador de repositórios Git é por meio dos repositórios do Ubuntu. Em um terminal, digite os seguintes comandos. Os comandos irão solicitar privilégios de administrador e sua senha.
-
-```shell
-
-sudo add-apt-repository ppa:git-core/ppa
-sudo apt-get update
-```
-
-O primeiro comando adicionará o repositório do Git na listagem de repositórios do Ubuntu. O segundo comando irá atualizar o nosso sistema com a nova adição, bem como procurar por modificações nos demais repositórios já existentes. 
-
-A seguir, devemos executar o comando para instalação o Git:
+A seguir, devemos executar o comando para instalação o Git. Não é necessário adicionar o repositório Git ao Ubuntu pois há tempos ele já se encontra em seu repositório:
 
 ```shell
 
@@ -27,8 +17,6 @@ git config --global user.email seu_email@email.com
 ```
 
 Com esses comandos, a instalação do Git e uma configuração básica de identificação está completa. 
-
-*Devido a ter sido instalado por meio de PPA, seu Git sempre será atualizado junto com as demais atualizações do sistema, de maneira muito cômoda mantendo-o sempre na versão mais atual :)
 
 Opcionalmente você também pode instalar o [tig](https://jonas.github.io/tig/doc/manual.html). Uma ferramenta de linha de comando em modo gráfico para navegar pelo histórico de commits.
 ```shell


### PR DESCRIPTION
O Git vem por padrão nos repositórios desde versões antigas. Não é necessário adicionar PPA. Em verdade, evitar o uso de PPA é uma boa prática. Apenas em caso de indisponibilidade de outras soluções sim usar o PPA